### PR TITLE
feat: add filter flag and fix typo in command description

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,15 +34,27 @@ Target directory can be passed in as an arg either as a relative path or an abso
 
 ### Additional flags
 
+#### Sort
 Sort flag `-s` or `--sort` can be used to sort the results by a specific key
 
 `repocheck --sort=name` to sort by repo name
 
 `repocheck -s=synced` to sort by sync status of the repo - unsynced repos will be at the top
 
+#### Filter
+Filter flag `-F` or `--filter` can be used to filter the results by either
+sync status or last modified date
+
+`repocheck --filter synced=yes` to only show repos that are synced
+
+`repocheck -F lastmodified=2024-01-01` to only show repos that were last modified on 2024-01-01
+
+
+`repocheck -F "lastmodified>=2024-01-01"` to only show repos that were last modified on or later than 2024-01-01
+
+*Note: for options containing '<' or '>' surround the entire filter option with quotes to prevent them from being interpreted as operators by bash*
 
 # Planned features
-- [ ] Add flag to filter the results by last modified date and sync status
 - [ ] Add flag for plain output to only output the absolute paths of the repos
 - [ ] Add flag for json output
 - [ ] Add head and tail flag to limit output

--- a/app/filter.go
+++ b/app/filter.go
@@ -1,0 +1,222 @@
+package app
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+type FilterStrategy interface {
+	ValidateQuery(string) error
+	Apply([]Repo, string) ([]Repo, error)
+}
+
+type SyncedEQFilterStrategy struct{}
+
+func (s SyncedEQFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "synced=")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'synced' but got query: %v", query)
+	}
+	if queryValue != "yes" &&
+		queryValue != "y" &&
+		queryValue != "no" &&
+		queryValue != "n" {
+		return fmt.Errorf("incorrect value for synced, value must be either 'yes', 'y', 'no' or 'n'")
+	}
+	return nil
+}
+
+func (s SyncedEQFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "synced=")
+	var queryBool bool
+	if queryValue == "yes" || queryValue == "y" {
+		queryBool = true
+	} else {
+		queryBool = false
+	}
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		if repo.SyncedWithRemote == queryBool {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+
+type LastModifiedEQFilterStrategy struct{}
+
+func (s LastModifiedEQFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "lastmodified=")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'lastmodified' but got query: %v", query)
+	}
+	_, err := time.Parse(time.DateOnly, queryValue)
+	if err != nil {
+		return fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query %v with date %v", query, queryValue)
+	}
+	return nil
+}
+
+func (s LastModifiedEQFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "lastmodified=")
+	queryDate, _ := time.Parse(time.DateOnly, queryValue)
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		// compare string representations of date to exclude time in comparison
+		if repo.LastModified.Format(time.DateOnly) == queryDate.Format(time.DateOnly) {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+
+type LastModifiedLEQFilterStrategy struct{}
+
+func (s LastModifiedLEQFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "lastmodified<=")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'lastmodified' but got query: %v", query)
+	}
+	_, err := time.Parse(time.DateOnly, queryValue)
+	if err != nil {
+		return fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query %v with date %v", query, queryValue)
+	}
+	return nil
+}
+
+func (s LastModifiedLEQFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "lastmodified<=")
+	queryDate, _ := time.Parse(time.DateOnly, queryValue)
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		// compare string representations of date to exclude time in comparison
+		if repo.LastModified.Format(time.DateOnly) <= queryDate.Format(time.DateOnly) {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+
+type LastModifiedGEQFilterStrategy struct{}
+
+func (s LastModifiedGEQFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "lastmodified>=")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'lastmodified' but got query: %v", query)
+	}
+	_, err := time.Parse(time.DateOnly, queryValue)
+	if err != nil {
+		return fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query %v with date %v", query, queryValue)
+	}
+	return nil
+}
+
+func (s LastModifiedGEQFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "lastmodified>=")
+	queryDate, _ := time.Parse(time.DateOnly, queryValue)
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		// compare string representations of date to exclude time in comparison
+		if repo.LastModified.Format(time.DateOnly) >= queryDate.Format(time.DateOnly) {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+
+type LastModifiedLESFilterStrategy struct{}
+
+func (s LastModifiedLESFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "lastmodified<")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'lastmodified' but got query: %v", query)
+	}
+	_, err := time.Parse(time.DateOnly, queryValue)
+	if err != nil {
+		return fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query %v with date %v", query, queryValue)
+	}
+	return nil
+}
+
+func (s LastModifiedLESFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "lastmodified<")
+	queryDate, _ := time.Parse(time.DateOnly, queryValue)
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		// compare string representations of date to exclude time in comparison
+		if repo.LastModified.Format(time.DateOnly) < queryDate.Format(time.DateOnly) {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+
+type LastModifiedGRTFilterStrategy struct{}
+
+func (s LastModifiedGRTFilterStrategy) ValidateQuery(query string) error {
+	queryValue, ok := strings.CutPrefix(query, "lastmodified>")
+	if !ok {
+		return fmt.Errorf("query mismatch, expected query to start with 'lastmodified' but got query: %v", query)
+	}
+	_, err := time.Parse(time.DateOnly, queryValue)
+	if err != nil {
+		return fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query %v with date %v", query, queryValue)
+	}
+	return nil
+}
+
+func (s LastModifiedGRTFilterStrategy) Apply(repos []Repo, query string) ([]Repo, error) {
+	err := s.ValidateQuery(query)
+	if err != nil {
+		return nil, err
+	}
+	queryValue, _ := strings.CutPrefix(query, "lastmodified>")
+	queryDate, _ := time.Parse(time.DateOnly, queryValue)
+	var filteredRepos []Repo
+	for _, repo := range repos {
+		// compare string representations of date to exclude time in comparison
+		if repo.LastModified.Format(time.DateOnly) > queryDate.Format(time.DateOnly) {
+			filteredRepos = append(filteredRepos, repo)
+		}
+	}
+	return filteredRepos, nil
+}
+func GetFilterStrategy(query string) (FilterStrategy, error) {
+	switch {
+	case strings.HasPrefix(query, "synced="):
+		return SyncedEQFilterStrategy{}, nil
+	case strings.HasPrefix(query, "lastmodified="):
+		return LastModifiedEQFilterStrategy{}, nil
+	case strings.HasPrefix(query, "lastmodified<="):
+		return LastModifiedLEQFilterStrategy{}, nil
+	case strings.HasPrefix(query, "lastmodified>="):
+		return LastModifiedGEQFilterStrategy{}, nil
+	case strings.HasPrefix(query, "lastmodified<"):
+		return LastModifiedLESFilterStrategy{}, nil
+	case strings.HasPrefix(query, "lastmodified>"):
+		return LastModifiedGRTFilterStrategy{}, nil
+	default:
+		return nil, fmt.Errorf("%v is not a valid filter option. Examples of options: synced=no | lastmodified=2024-01-20 | \"lastmodified<2024-01-15\" | \"lastmodified>=2023-12-22\"", query)
+	}
+}

--- a/app/filter_test.go
+++ b/app/filter_test.go
@@ -1,0 +1,473 @@
+package app
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+var (
+	jan1, _  = time.Parse(time.DateOnly, "2024-01-01")
+	jan2, _  = time.Parse(time.DateOnly, "2024-01-02")
+	jan3, _  = time.Parse(time.DateOnly, "2024-01-03")
+	jan3a, _ = time.Parse(time.DateTime, "2024-01-03 10:00:00")
+	jan4, _  = time.Parse(time.DateOnly, "2024-01-04")
+)
+
+var getFilterStrategyTests = []struct {
+	query string
+	want  reflect.Type
+}{
+	{
+		"synced=yes",
+		reflect.TypeOf(SyncedEQFilterStrategy{}),
+	},
+	{
+		"synced=no",
+		reflect.TypeOf(SyncedEQFilterStrategy{}),
+	},
+	{
+		"lastmodified=2024-01-03",
+		reflect.TypeOf(LastModifiedEQFilterStrategy{}),
+	},
+	{
+		"lastmodified<=2024-01-03",
+		reflect.TypeOf(LastModifiedLEQFilterStrategy{}),
+	},
+	{
+		"lastmodified>=2024-01-03",
+		reflect.TypeOf(LastModifiedGEQFilterStrategy{}),
+	},
+	{
+		"lastmodified<2024-01-03",
+		reflect.TypeOf(LastModifiedLESFilterStrategy{}),
+	},
+	{
+		"lastmodified>2024-01-03",
+		reflect.TypeOf(LastModifiedGRTFilterStrategy{}),
+	},
+	{
+		"invalidQuery",
+		nil,
+	},
+}
+
+func TestGetFilterStrategy(t *testing.T) {
+	for _, test := range getFilterStrategyTests {
+		filterStrategy, _ := GetFilterStrategy(test.query)
+		if reflect.TypeOf(filterStrategy) != test.want {
+			t.Errorf(
+				"got (%v) , want (%v)",
+				reflect.TypeOf(filterStrategy),
+				test.want,
+			)
+		}
+	}
+}
+
+func TestGetFilterStrategyError(t *testing.T) {
+	wantE := fmt.Errorf("invalidQuery is not a valid filter option. Examples of options: synced=no | lastmodified=2024-01-20 | \"lastmodified<2024-01-15\" | \"lastmodified>=2023-12-22\"")
+	got, gotE := GetFilterStrategy("invalidQuery")
+	if got != nil || gotE.Error() != wantE.Error() {
+		t.Errorf(
+			"got (%v, %v) , want (%v, %v)",
+			got, gotE.Error(),
+			nil, wantE.Error(),
+		)
+	}
+}
+
+var syncedEQFilterStrategyTests = []struct {
+	query string
+	want  []Repo
+}{
+	{
+		"synced=yes",
+		getFilteredOutputByQuery("synced=yes"),
+	},
+	{
+		"synced=y",
+		getFilteredOutputByQuery("synced=yes"),
+	},
+	{
+		"synced=no",
+		getFilteredOutputByQuery("synced=no"),
+	},
+	{
+		"synced=n",
+		getFilteredOutputByQuery("synced=no"),
+	},
+}
+
+func TestSyncedEQFilterStrategy(t *testing.T) {
+	for _, test := range syncedEQFilterStrategyTests {
+		syncedEQFilter := SyncedEQFilterStrategy{}
+		repos := getUnfilteredRepos()
+		got, _ := syncedEQFilter.Apply(repos, test.query)
+		if !reflect.DeepEqual(got, test.want) {
+			t.Errorf(
+				"got (%v)\nwant (%v)",
+				got,
+				test.want,
+			)
+		}
+	}
+}
+
+func TestSyncedEQFilterStrategyError(t *testing.T) {
+	wantE := fmt.Errorf("incorrect value for synced, value must be either 'yes', 'y', 'no' or 'n'")
+	repos := getUnfilteredRepos()
+	got, gotE := SyncedEQFilterStrategy{}.Apply(repos, "synced=invalid")
+	if got != nil || gotE.Error() != wantE.Error() {
+		t.Errorf(
+			"got (%v, %v) , want (%v, %v)",
+			got, gotE.Error(),
+			nil, wantE.Error(),
+		)
+	}
+
+}
+
+func TestLastModifiedEQFilterStrategy(t *testing.T) {
+	want := getFilteredOutputByQuery("lastmodified=2024-01-03")
+	repos := getUnfilteredRepos()
+	got, _ := LastModifiedEQFilterStrategy{}.Apply(repos, "lastmodified=2024-01-03")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"got (%v)\nwant (%v)",
+			got,
+			want,
+		)
+	}
+}
+
+func TestLastModifiedLEQFilterStrategy(t *testing.T) {
+	want := getFilteredOutputByQuery("lastmodified<=2024-01-03")
+	repos := getUnfilteredRepos()
+	got, _ := LastModifiedLEQFilterStrategy{}.Apply(repos, "lastmodified<=2024-01-03")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"got (%v)\nwant (%v)",
+			got,
+			want,
+		)
+	}
+}
+
+func TestLastModifiedGEQFilterStrategy(t *testing.T) {
+	want := getFilteredOutputByQuery("lastmodified>=2024-01-03")
+	repos := getUnfilteredRepos()
+	got, _ := LastModifiedGEQFilterStrategy{}.Apply(repos, "lastmodified>=2024-01-03")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"got (%v)\nwant (%v)",
+			got,
+			want,
+		)
+	}
+}
+
+func TestLastModifiedLESFilterStrategy(t *testing.T) {
+	want := getFilteredOutputByQuery("lastmodified<2024-01-03")
+	repos := getUnfilteredRepos()
+	got, _ := LastModifiedLESFilterStrategy{}.Apply(repos, "lastmodified<2024-01-03")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"got (%v)\nwant (%v)",
+			got,
+			want,
+		)
+	}
+}
+
+func TestLastModifiedGRTFilterStrategy(t *testing.T) {
+	want := getFilteredOutputByQuery("lastmodified>2024-01-03")
+	repos := getUnfilteredRepos()
+	got, _ := LastModifiedGRTFilterStrategy{}.Apply(repos, "lastmodified>2024-01-03")
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf(
+			"got (%v)\nwant (%v)",
+			got,
+			want,
+		)
+	}
+}
+
+var lastModifiedFilterStrategyErrorTests = []struct {
+	query    string
+	strategy FilterStrategy
+	wantE    error
+}{
+	{
+		"lastmodified=invalid",
+		LastModifiedEQFilterStrategy{},
+		fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query lastmodified=invalid with date invalid"),
+	},
+	{
+		"lastmodified<=invalid",
+		LastModifiedLEQFilterStrategy{},
+		fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query lastmodified<=invalid with date invalid"),
+	},
+	{
+		"lastmodified>=invalid",
+		LastModifiedGEQFilterStrategy{},
+		fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query lastmodified>=invalid with date invalid"),
+	},
+	{
+		"lastmodified<invalid",
+		LastModifiedLESFilterStrategy{},
+		fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query lastmodified<invalid with date invalid"),
+	},
+	{
+		"lastmodified>invalid",
+		LastModifiedGRTFilterStrategy{},
+		fmt.Errorf("unexpected date, date must be in the format yyyy-mm-dd but got query lastmodified>invalid with date invalid"),
+	},
+}
+
+func TestLastModifiedFilterStrategyError(t *testing.T) {
+	for _, test := range lastModifiedFilterStrategyErrorTests {
+		lastModifiedFilterStrategy := test.strategy
+		gotE := lastModifiedFilterStrategy.ValidateQuery(test.query)
+		if gotE == nil || gotE.Error() != test.wantE.Error() {
+			t.Errorf(
+				"got (%v)\nwant (%v)",
+				gotE,
+				test.wantE,
+			)
+		}
+	}
+}
+
+func getUnfilteredRepos() []Repo {
+	// helper to provide fake input to test filter strategy
+	return []Repo{
+		{
+			"c",
+			"repos/c",
+			"/home/user/repos/z/c",
+			jan1,
+			false,
+			"",
+			true,
+		},
+		{
+			"d",
+			"repos/d",
+			"/home/user/repos/w/d",
+			jan2,
+			true,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3,
+			false,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3a,
+			true,
+			"",
+			true,
+		},
+		{
+			"b",
+			"repos/b",
+			"/home/user/repos/y/b",
+			jan4,
+			true,
+			"",
+			true,
+		},
+	}
+}
+
+func getFilteredOutputByQuery(query string) []Repo {
+	// helper to provide expected outputs for each filter strategy apply
+	filteredBySyncYes := []Repo{
+		{
+			"d",
+			"repos/d",
+			"/home/user/repos/w/d",
+			jan2,
+			true,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3a,
+			true,
+			"",
+			true,
+		},
+		{
+			"b",
+			"repos/b",
+			"/home/user/repos/y/b",
+			jan4,
+			true,
+			"",
+			true,
+		},
+	}
+	filteredBySyncNo := []Repo{
+		{
+			"c",
+			"repos/c",
+			"/home/user/repos/z/c",
+			jan1,
+			false,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3,
+			false,
+			"",
+			true,
+		},
+	}
+	filteredByLastModifiedEQjan3 := []Repo{
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3,
+			false,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3a,
+			true,
+			"",
+			true,
+		},
+	}
+	filteredByLastModifiedLEQjan3 := []Repo{
+		{
+			"c",
+			"repos/c",
+			"/home/user/repos/z/c",
+			jan1,
+			false,
+			"",
+			true,
+		},
+		{
+			"d",
+			"repos/d",
+			"/home/user/repos/w/d",
+			jan2,
+			true,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3,
+			false,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3a,
+			true,
+			"",
+			true,
+		},
+	}
+	filteredByLastModifiedGEQjan3 := []Repo{
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3,
+			false,
+			"",
+			true,
+		},
+		{
+			"a",
+			"repos/a",
+			"/home/user/repos/x/a",
+			jan3a,
+			true,
+			"",
+			true,
+		},
+		{
+			"b",
+			"repos/b",
+			"/home/user/repos/y/b",
+			jan4,
+			true,
+			"",
+			true,
+		},
+	}
+	filteredByLastModifiedLESjan3 := []Repo{
+		{
+			"c",
+			"repos/c",
+			"/home/user/repos/z/c",
+			jan1,
+			false,
+			"",
+			true,
+		},
+		{
+			"d",
+			"repos/d",
+			"/home/user/repos/w/d",
+			jan2,
+			true,
+			"",
+			true,
+		},
+	}
+	filteredByLastModifiedGRTjan3 := []Repo{
+		{
+			"b",
+			"repos/b",
+			"/home/user/repos/y/b",
+			jan4,
+			true,
+			"",
+			true,
+		},
+	}
+	outputOptions := map[string][]Repo{
+		"synced=yes":               filteredBySyncYes,
+		"synced=no":                filteredBySyncNo,
+		"lastmodified=2024-01-03":  filteredByLastModifiedEQjan3,
+		"lastmodified<=2024-01-03": filteredByLastModifiedLEQjan3,
+		"lastmodified>=2024-01-03": filteredByLastModifiedGEQjan3,
+		"lastmodified<2024-01-03":  filteredByLastModifiedLESjan3,
+		"lastmodified>2024-01-03":  filteredByLastModifiedGRTjan3,
+	}
+	return outputOptions[query]
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -13,8 +13,8 @@ var FilterQuery string
 
 var rootCmd = &cobra.Command{
 	Use:   "repocheck",
-	Short: "repocheck is a cli tool show repos and info about them in a directory",
-	Long:  "repocheck is a cli tool show repos and info about them in a directory - see info for each repo such as absolute path of repo, last modified date, whether repo is synced with remote (whether it has uncommited changtes or branches that are ahead etc.)",
+	Short: "repocheck is a cli tool to show repos in a directory and info about them",
+	Long:  "repocheck is a cli tool to show repos in a directory and info about them - see info for each repo such as absolute path of repo, last modified date, whether repo is synced with remote (whether it has uncommited changes or branches that are ahead etc.)",
 	Args:  cobra.MaximumNArgs(1),
 	RunE:  repocheckCmd,
 }


### PR DESCRIPTION
**Changes**
- Added filter flag, usage:
  - `repocheck --filter synced=yes` to only show repos that are synced
  - `repocheck -F lastmodified=2024-01-01` to only show repos that were last modified on 2024-01-01
  - `repocheck -F "lastmodified>=2024-01-01"` to only show repos that were last modified on or later than 2024-01-01
- Fixed typos in command description